### PR TITLE
Upgrade to Kotlin 1.5.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 buildscript {
   repositories {
     mavenCentral()
@@ -7,7 +5,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.10"
     classpath "com.diffplug.spotless:spotless-plugin-gradle:5.12.4"
     classpath "com.vanniktech:gradle-maven-publish-plugin:0.14.2"
     classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.4.30"
@@ -46,17 +44,6 @@ dependencies {
   implementation "gradle.plugin.org.jetbrains.intellij.plugins:gradle-grammarkit-plugin:2020.1.4"
 
   compileOnly gradleApi()
-}
-
-plugins.withId("org.jetbrains.kotlin.jvm") {
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
-}
-
-tasks.withType(KotlinCompile) {
-  kotlinOptions {
-    jvmTarget = "1.8"
-  }
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"


### PR DESCRIPTION
The [new default JVM target is 1.8](https://kotlinlang.org/docs/whatsnew15.html#new-default-jvm-target-1-8), so we don't have to explicitly specify it anymore.