### PR TITLE
Adopt custom parser to upstream changes

### DIFF
--- a/src/main/kotlin/com/alecstrong/grammar/kit/composer/BnfExtenderTask.kt
+++ b/src/main/kotlin/com/alecstrong/grammar/kit/composer/BnfExtenderTask.kt
@@ -261,7 +261,7 @@ private class GrammarFile(
                     if (it == "true") {
                       overrideMethod.addStatement(
                         "%T.$key = Parser { psiBuilder, i -> " +
-                          "${key.toFunctionName()}(psiBuilder, i, %T.${key}_real_parser_)" +
+                          "$key?.parse(psiBuilder, i) ?: %T.${key}_real(psiBuilder, i)" +
                           " }",
                         overrides.util(), outputs.parserClass
                       )


### PR DESCRIPTION
Before:
```kt
 SqlParserUtil.type_name = Parser { psiBuilder, i -> typeNameExt(psiBuilder, i,
        HsqlParser.type_name_real_parser_) } // error: type_name_real_parser_ not found
```

Now:
```kt
SqlParserUtil.type_name = Parser { psiBuilder, i -> type_name?.parse(psiBuilder, i) ?:
        HsqlParser.type_name_real(psiBuilder, i) } // compiles with sql-psi, all tests passed
```