### PR TITLE
Remove removed JVM args in jdk17

### DIFF
--- a/.github/workflows/SNAPSHOT.yml
+++ b/.github/workflows/SNAPSHOT.yml
@@ -26,4 +26,4 @@ jobs:
       run: ./gradlew publish --no-daemon --stacktrace
 
 env:
-  GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=false -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+  GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=false -Dkotlin.incremental=false


### PR DESCRIPTION
Only `MaxPermSize` is removed but the other args are useless for this small library/build. I copied them from sqldelight requiring more memory.